### PR TITLE
Merge from ls990: Fix apps2sd to usb storage

### DIFF
--- a/rootdir/etc/fstab.g3
+++ b/rootdir/etc/fstab.g3
@@ -21,4 +21,4 @@
 /dev/block/platform/msm_sdcc.1/by-name/mpt          /mpt            ext4    nosuid,nodev,barrier=1,noatime,noauto_da_alloc,errors=continue wait
 
 /devices/msm_sdcc.3/mmc_host*                       auto            auto    defaults voldmanaged=sdcard1:auto,noemulatedsd
-/devices/platform/xhci-hcd*                         auto            auto    defaults voldmanaged=usbdisk0:auto
+/devices/platform/xhci-hcd*                         auto            auto    defaults voldmanaged=usbdisk0:auto,noemulatedsd


### PR DESCRIPTION
While this may not be a very good idea to use (do you really want
to have a usb stick sticking out of your phone??), the current
fstab is incorrect and needs to be fixed.

Removable storage is always noemulatedsd (and defined as such
in storage_list.xml).  The fstab should be consistent with the
rest of android.

Change-Id: Ie49ef93bbaf3df53f90fbfab3b336a0c56585be6
