### PR TITLE
ls990: decommonize NFC config and HCE permission

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -38,6 +38,9 @@ TARGET_USERIMAGES_USE_F2FS := true
 # Recovery
 TARGET_RECOVERY_FSTAB := device/lge/ls990/rootdir/etc/fstab.g3
 
+# NFC
+BOARD_NFC_CHIPSET := pn544
+
 # Wifi
 BOARD_WLAN_DEVICE := bcmdhd
 BOARD_HOSTAPD_DRIVER := NL80211

--- a/device.mk
+++ b/device.mk
@@ -34,6 +34,13 @@ DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
 PRODUCT_PACKAGES += \
     libnetcmdiface
 
+# NFC packages
+PRODUCT_PACKAGES += \
+    nfc.default \
+    libnfc \
+    libnfc_jni \
+    Nfc
+
 # Get BCMDHD configs
 $(call inherit-product-if-exists, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
 


### PR DESCRIPTION
- The ls990 uses a pn544 instead of a pn547 so move BOARD_NFC_CHIPSET
  to the device folders
- Since the pn544 doesn't support HCE, move the permission for it
  to the device folders as well, otherwise, it will cause linker
  errors on the ls990
- Build defualt NFC HALs on the ls990 since the pn54x HALs dont work
  that well

Needs https://github.com/TheMuppets/proprietary_vendor_lge/pull/79

Change-Id: I3dac9bc173c788617f568edfef338e1d5dff8286
