### PR TITLE
ls990: enable pin/puk reads for RIL and Sprint SIM hack

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -8,6 +8,7 @@ ro.cdma.home.operator.alpha=Sprint
 telephony.lteOnCdmaDevice=1
 telephony.lte.cdma.device=1
 ro.telephony.default_network=8
+ro.telephony.ril.config=needPinPukReads,sprintSimHack
 ro.ril.def.preferred.network=8
 ril.subscription.types=NV,RUIM
 persist.radio.no_wait_for_card=1


### PR DESCRIPTION
Change-Id: Ia0507250f271e7828e0a367efe1875bf630dec9f
